### PR TITLE
changes to options and blitter for 1.2

### DIFF
--- a/arcore-android-sdk/samples/hello_cloudxr_c/app/src/main/cpp/blitter.cc
+++ b/arcore-android-sdk/samples/hello_cloudxr_c/app/src/main/cpp/blitter.cc
@@ -51,7 +51,6 @@ const vec2 positions[4] = vec2[4](
 void main() {
   gl_Position = vec4(positions[gl_VertexID], 0.0, 1.0);
   vsUV0 = positions[gl_VertexID]/2.0 + vec2(0.5, 0.5);
-  vsUV0.y = 1.f - vsUV0.y;
 }
 )";
 

--- a/arcore-android-sdk/samples/hello_cloudxr_c/app/src/main/cpp/hello_ar_application.cc
+++ b/arcore-android-sdk/samples/hello_cloudxr_c/app/src/main/cpp/hello_ar_application.cc
@@ -72,17 +72,17 @@ protected:
     // we override for extra cmdline options...
     virtual void HandleArg(std::string &tok)
     {
-      if (tok == "-e" || tok == "-envlighting") { // env lighting flag
+      if (tok == "-e" || tok == "-env-lighting") { // env lighting flag
         GetNextToken(tok);
-        if (tok=="1" || tok=="on") {
+        if (tok=="1") {
           using_env_lighting_ = true;
         }
-        else if (tok=="0" || tok=="off") {
+        else if (tok=="0") {
           using_env_lighting_ = false;
         }
-        // else leave as whatever default is...
+        // else leave as-is...
       }
-      else if (tok == "-r" || tok == "-resfactor") { // resfactor override
+      else if (tok == "-r" || tok == "-res-factor") { // resfactor override
         GetNextToken(tok);
         float factor = std::stof(tok);
         if (factor >= 0.5f && factor <= 1.0f)


### PR DESCRIPTION
-tweaks to launch option names
- for boolean options, just use 0+1
- launch option - prefix required
- all launch option names lowercased for compares
- fixed a bug where launch option needed a space or LF at the end or we missed final option
- some new options in the base class
- fix to the blitter shader to not invert Y, as we removed a flip elsewhere in the cloudxr client library.